### PR TITLE
v5.0.1 (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This guide will assume you've left `app` in `src` (the way it should be).
 | Version | Release Date |
 | ------- | ------------ |
 | 5.0.0   | 3/10/2022    |
+| 5.0.1   | 3/15/2022    |
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/src/app/cfg/app.js
+++ b/src/app/cfg/app.js
@@ -15,8 +15,8 @@ const app = {
     version: {
         major: 5,
         minor: 0,
-        revision: 0,
-        buildType: "A",
+        revision: 1,
+        buildType: "R",
         toString: function() {
             var major = app.version.major,
                 minor = app.version.minor,

--- a/src/app/cmds/General/userinfo.js
+++ b/src/app/cmds/General/userinfo.js
@@ -29,7 +29,6 @@ module.exports = {
                 user.tag = `${user.username}#${user.discriminator}`; // Manually add this so it looks cool
 
                 var embed = {
-                    thumbnail: { url: `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.${app.functions.isAnimated(user.avatar) ? "gif": "png"}?size=1024` },
                     title: `${app.config.system.emotes.information} **${user.tag} ${(user.bot ? "*[BOT]*" : "")}**`,
                     color: (user["accent_color"]) ? user["accent_color"] : app.config.system.embedColors.blue,
                     fields: [
@@ -39,6 +38,12 @@ module.exports = {
                         { name: "User ID", value: user.id, inline: false },
                     ]
                 };
+
+                if (user.avatar != null)
+                    embed["thumbnail"] = { url: `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.${app.functions.isAnimated(user.avatar) ? "gif": "png"}?size=1024` };
+                else
+                    embed["thumbnail"] = { url: `https://cdn.discordapp.com/embed/avatars/${user.discriminator % 5}.png?size=1024` };
+
 
                 if (user.banner != null)
                     embed["image"] = { url: `https://cdn.discordapp.com/banners/${user.id}/${user.banner}.${app.functions.isAnimated(user.banner) ? "gif": "png"}?size=600` };

--- a/src/app/cmds/Moderation/config.js
+++ b/src/app/cmds/Moderation/config.js
@@ -325,15 +325,15 @@ module.exports = {
                                             msgCollector.stop("cancelled by user");
                                             m.react(app.config.system.emotes.success).catch(err => {});
                                         } else if (m.content == "next") {
-                                            var tmpContent = JSON.parse(serverSettings.get("other")[val]) || { msg: defaults[val][msg], channel: null };
+                                            var tmpContent = (serverSettings.get("other")[val]) ? JSON.parse(serverSettings.get("other")[val]) || { msg: defaults[val]["msg"], channel: null } : { msg: defaults[val]["msg"], channel: null };
                                             if (tmpContent["msg"]) {
                                                 msgCollector.stop("done");
-                                                await collectJoinLeaveChannel(val, null);
+                                                await collectJoinLeaveChannel(val, tmpContent);
                                                 m.react(app.config.system.emotes.success).catch(err => {});
                                             } else m.react(app.config.system.emotes.error).catch(err => {});
                                         } else {
                                             msgCollector.stop("done");
-                                            var tmpContent = { msg: m.content || defaults[val][msg], channel: null };
+                                            var tmpContent = { msg: m.content || defaults[val]["msg"], channel: null };
                                             await collectJoinLeaveChannel(val, tmpContent);
                                             m.react(app.config.system.emotes.success).catch(err => {});
                                         }
@@ -432,7 +432,7 @@ module.exports = {
                                                 embeds: [{
                                                     title: `${app.config.system.emotes.success} Configure ${app.name}`,
                                                     color: app.config.system.embedColors.lime,
-                                                    description: `Woohoo! We're done here!\nYour ${evtType} message & channel are both ready to go!`
+                                                    description: `Woohoo! We're done here!\nYour ${evtType} message & channel are both ready to go!\n\n\`${evtData["msg"]}\``
                                                 }],
                                                 components: [],
                                                 author: message.author

--- a/src/app/cmds/Owner/botcontrols.js
+++ b/src/app/cmds/Owner/botcontrols.js
@@ -29,7 +29,7 @@ module.exports = {
                     title: `${app.config.system.emotes.warning} **${type}**`,
                     color: app.config.system.embedColors.yellow,
                     fields: [
-                        { name: `Are you sure you wish for me to ${type}?`, value: `To confirm, use the buttons.${((type == "Restart") ? "\n*This will not reload the main bot file.*" : "")}` }
+                        { name: `Are you sure you wish for me to ${type}?`, value: `To confirm, use the buttons.` }
                     ]
                 }],
                 components: [row]
@@ -51,10 +51,9 @@ module.exports = {
                         }, 1, true, (async() => {
                             app.logger.debug("SYS", `${app.name} ${actionDoing.toLowerCase()} as of ${new Date()}.`);
                             if (type == "Restart") {
-                                await process.exitHandler({ app: app, cleanup: true, exit: false }, 0);
+                                try { app.modules.fs.writeFileSync(process.cwd() + "/cache/restart.tmp", msg.channel.id + "-" + msg.id); } catch (Ex) {};
+                                await process.exitHandler({ app: app, cleanup: true, exit: false, restart: true }, 0);
 
-                                await app.functions.clearCache();
-                                await app.botStart(msg.channel.id + "-" + msg.id);
                             } else { process.exitHandler({ app: app, cleanup: true, exit: true }, 0); };
                         }));
                         denied = false, buttonStuffWaiting = false;

--- a/src/app/evts/channelCreate.js
+++ b/src/app/evts/channelCreate.js
@@ -31,7 +31,7 @@ module.exports = async(app, newChannel) => {
 
         //define channelLog
         const channelLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the channel was created.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (channelLog) {
             const { executor } = channelLog;

--- a/src/app/evts/channelDelete.js
+++ b/src/app/evts/channelDelete.js
@@ -30,7 +30,7 @@ module.exports = async(app, oldChannel) => {
     if (fetchedLogs) {
         //define channelLog
         const channelLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the channel was deleted.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (channelLog) {
             const { executor } = channelLog;

--- a/src/app/evts/channelUpdate.js
+++ b/src/app/evts/channelUpdate.js
@@ -49,7 +49,7 @@ module.exports = async(app, oldChannel, newChannel) => {
 
         //define channelLog
         const channelLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the channel was updated.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (channelLog) {
             const { executor } = channelLog;

--- a/src/app/evts/emojiCreate.js
+++ b/src/app/evts/emojiCreate.js
@@ -31,7 +31,7 @@ module.exports = async(app, newEmoji) => {
 
         //define emojiLog
         const emojiLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the emoji was created.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (emojiLog) {
             const { executor } = emojiLog;

--- a/src/app/evts/emojiDelete.js
+++ b/src/app/evts/emojiDelete.js
@@ -31,7 +31,7 @@ module.exports = async(app, oldEmoji) => {
 
         //define emojiLog
         const emojiLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the emoji was created.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (emojiLog) {
             const { executor } = emojiLog;

--- a/src/app/evts/emojiUpdate.js
+++ b/src/app/evts/emojiUpdate.js
@@ -41,7 +41,7 @@ module.exports = async(app, oldEmoji, newEmoji) => {
 
         //define emojiLog
         const emojiLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the emoji was updated.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (emojiLog) {
             const { executor } = emojiLog;

--- a/src/app/evts/guildBanAdd.js
+++ b/src/app/evts/guildBanAdd.js
@@ -33,7 +33,7 @@ module.exports = async(app, ban) => {
 
         //define banLog
         const banLog = fetchedLogs.entries.find(entry => { // To avoid false positives, we look for a timeframe of when the ban was created, and if the user banned is the correct entry.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         });
         if (banLog) {
             const { executor } = banLog;

--- a/src/app/evts/guildBanRemove.js
+++ b/src/app/evts/guildBanRemove.js
@@ -33,7 +33,7 @@ module.exports = async(app, ban) => {
 
         //define banLog
         const banLog = fetchedLogs.entries.find(entry => { // To avoid false positives, we look for a timeframe of when the ban was created, and if the user banned is the correct entry.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         });
         if (banLog) {
             const { executor } = banLog;

--- a/src/app/evts/guildMemberRemove.js
+++ b/src/app/evts/guildMemberRemove.js
@@ -35,7 +35,7 @@ module.exports = async(app, oldMember) => {
 
             //define kickLog
             const kickLog = fetchedLogs.entries.find(entry => { // To avoid false positives, we look for a timeframe of when the ban was created, and if the user banned is the correct entry.
-                Date.now() - entry.createdTimestamp < 20000
+                Date.now() - entry.createdTimestamp < 5000
             });
             if (kickLog) {
                 const { executor } = kickLog;

--- a/src/app/evts/guildMemberUpdate.js
+++ b/src/app/evts/guildMemberUpdate.js
@@ -42,7 +42,7 @@ module.exports = async(app, oldMember, newMember) => {
         else if (oldMember.roles.cache.size < newMember.roles.cache.size) embed.fields.push({ name: "Roles Added", value: roleUpdated.join(", ") || "Failed to get roles added" }); // ooo features
     };
 
-    if (!embed.fields.length > 3) return; // Since we aren't subscribing to all updates, stop here if it was something else non-related to what we have.
+    if (embed.fields.length < 3) return; // Since we aren't subscribing to all updates, stop here if it was something else non-related to what we have.
 
     embed.fields.push({ name: "Updated At", value: new Date().toString() })
 
@@ -53,7 +53,7 @@ module.exports = async(app, oldMember, newMember) => {
 
         //define memberLog
         const memberLog = fetchedLogs.entries.filter(e => e.action === "MEMBER_UPDATE" || e.action === "MEMBER_ROLE_UPDATE").find(entry => // To avoid false positives, we look for a timeframe of when the member was updated.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (memberLog) {
             const { executor } = memberLog;

--- a/src/app/evts/guildUpdate.js
+++ b/src/app/evts/guildUpdate.js
@@ -87,7 +87,7 @@ module.exports = async(app, oldGuild, newGuild) => {
 
         //define guildLog
         const guildLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the guild was updated.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (guildLog) {
             const { executor } = guildLog;

--- a/src/app/evts/messageDelete.js
+++ b/src/app/evts/messageDelete.js
@@ -38,9 +38,9 @@ module.exports = async(app, message) => {
     }).catch(err => {});
     if (fetchedLogs) {
         const deleteLog = fetchedLogs.entries.find(entry => // To avoid false positives, we sort by message author, message channel, and a timeframe of when the message was deleted.
-            (message.author) ? entry.executor.id !== message.author.id : true &&
+            ((message.author) ? entry.executor.id !== message.author.id : true) &&
             entry.extra.channel.id === message.channel.id &&
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (deleteLog) { // If none, we may be missing permissions to fetch audit log.
             const { executor } = deleteLog;

--- a/src/app/evts/roleCreate.js
+++ b/src/app/evts/roleCreate.js
@@ -34,7 +34,7 @@ module.exports = async(app, newRole) => {
 
         //define roleLog
         const roleLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the role was created.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (roleLog) {
             const { executor } = roleLog;

--- a/src/app/evts/roleDelete.js
+++ b/src/app/evts/roleDelete.js
@@ -31,7 +31,7 @@ module.exports = async(app, oldRole) => {
 
         //define roleLog
         const roleLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the role was deleted.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (roleLog) {
             const { executor } = roleLog;

--- a/src/app/evts/roleUpdate.js
+++ b/src/app/evts/roleUpdate.js
@@ -67,7 +67,7 @@ module.exports = async(app, oldRole, newRole) => {
 
         //define roleLog
         const roleLog = fetchedLogs.entries.find(entry => // To avoid false positives, we look for a timeframe of when the role was updated.
-            Date.now() - entry.createdTimestamp < 20000
+            Date.now() - entry.createdTimestamp < 5000
         );
         if (roleLog) {
             const { executor } = roleLog;

--- a/src/app/functions/bootloader.js
+++ b/src/app/functions/bootloader.js
@@ -195,16 +195,21 @@ class BootLoader {
                         verification: app.db.define('verification', {
                             serverID: { // The executing server
                                 type: Sequelize.STRING,
-                                primaryKey: true
+                                defaultValue: null,
+                                unique: false
                             },
                             userID: { // The executing user
                                 type: Sequelize.STRING,
                                 defaultValue: null,
-                                allowNull: true
+                                allowNull: true,
+                                unique: true,
+                                primaryKey: true
+
                             },
                             messageID: { // Allows us to edit the same message (if in a server)
                                 type: Sequelize.STRING,
                                 defaultValue: null,
+                                unique: true,
                                 allowNull: true
                             },
                             userCode: { // The code generated


### PR DESCRIPTION
This update includes fixes to commands:
* userinfo -> corrected default avatar handling.
* config -> Patch bug where supplying 'next' to the default results in the bot having a fit about json in console, not continuing for user.
* botcontrols -> You can now restart the bot and actually restart it. No more reloading everything but the main bot.js file.

Also including fixes to:
* All events requiring audit log pulling -> Patched bug where fetching audit log data got the wrong user. For instance, for a user deleting their own message, it would show the last user who deleted their message prior.
* ready event -> Patched bug where invite caching causes 429 (ratelimit) errors and possible improper logging of invites.
* verification -> Patched bug where running multiple verification may cause the database to freak out because the primary key was set to serverID and not something like code.